### PR TITLE
Prevent Installing Dependencies in CI Scripts

### DIFF
--- a/eslint/entrypoint.sh
+++ b/eslint/entrypoint.sh
@@ -4,14 +4,8 @@
 set -e
 cd $GITHUB_WORKSPACE
 
-echo "# Installing yarn..."
-yarn install
-
-# Install ESLint if needed
-if ! yarn list | grep "eslint"; then
-  echo "\n# Installing ESLint..."
-  yarn add --non-interactive --silent --dev eslint --loglevel error
-fi
+echo "\n# Installing ESLint..."
+npm install -g eslint
 
 if [ -z "$1" ]; then
   glob="."
@@ -20,4 +14,4 @@ else
 fi
 
 echo "\n# Running ESLint..."
-sh -c "yarn run eslint $glob"
+sh -c "eslint $glob"

--- a/rubocop/entrypoint.sh
+++ b/rubocop/entrypoint.sh
@@ -4,16 +4,9 @@
 set -e
 cd $GITHUB_WORKSPACE
 
-if [ -f "Gemfile" ]; then
-  echo "# Bundling..."
-  bundle install --jobs 4 --retry 3
-fi
-
-# Setup Rubocop if needed
-if [ ! `which rubocop` ]; then
-  echo "\n# Installing rubocop..."
-  gem install rubocop
-fi
+# Setup Rubocop
+echo "\n# Installing rubocop..."
+gem install rubocop
 
 if [ -z "$1" ]; then
   glob="."

--- a/stylelint/entrypoint.sh
+++ b/stylelint/entrypoint.sh
@@ -4,14 +4,8 @@
 set -e
 cd $GITHUB_WORKSPACE
 
-echo "# Installing yarn..."
-yarn install
-
-# Install stylelint if needed
-if ! yarn list | grep "stylelint"; then
-  echo "\n# Installing stylelint..."
-  yarn add --non-interactive --silent --dev stylelint --loglevel error
-fi
+echo "\n# Installing stylelint..."
+npm install -g stylelint stylelint-scss stylelint-config-recommended-scss
 
 if [ -z "$1" ]; then
   glob="."
@@ -20,4 +14,4 @@ else
 fi
 
 echo "\n# Running stylelint..."
-sh -c "yarn run stylelint $glob"
+sh -c "stylelint $glob"


### PR DESCRIPTION
Each CI script runs in its own isolated container, and therefore is not
bound to the dependency requirements of the codebase that it's running
for. The static analysis scripts run really slowly due to the fact that
they `bundle install` and `yarn install` before each task, and this is
not only unnecessary but actually breaks the build for some gems in
legacy stable versions. To address this, remove `bundle install` and
`yarn install` lines from each script (with the exception of
`bundler-audit` since it needs to know the bundled gem versions) and
install the static gems/yarn dependencies globally to the container. Although
this removes any plugin's ability to customize the RuboCop version, we
can also be sure that each plugin will be tested consistently and we
won't be pinning them to legacy older versions of our CI tools.

This also runs `bundler-audit` at Ruby 2.4 since Flow will not run that
analysis without this change.