### PR TITLE
Ignore CVEs with Bundler Audit

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -4,3 +4,7 @@ author: 'Ben Crouse'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  ignored:
+    description: CVEs to ignore when running security checks
+    required: false

--- a/bundler-audit/entrypoint.sh
+++ b/bundler-audit/entrypoint.sh
@@ -16,4 +16,9 @@ if [ ! `which bundler-audit` ]; then
 fi
 
 echo "\n# Running bundler-audit..."
-sh -c "bundle audit check --update"
+
+if [ -n "$INPUT_IGNORED" ]; then
+  echo "bundle audit check --update --ignore ${INPUT_IGNORED}"
+else
+  echo "bundle audit check --update"
+fi


### PR DESCRIPTION
Adds the ability to pass a space-separated string of ignored CVEs to Bundler Audit.