### PR TITLE
Pass Options To Bundler Audit

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -4,3 +4,7 @@ author: 'Ben Crouse'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  args:
+    description: Arguments to pass to the bundler-audit command
+    required: false

--- a/bundler-audit/entrypoint.sh
+++ b/bundler-audit/entrypoint.sh
@@ -16,4 +16,4 @@ if [ ! `which bundler-audit` ]; then
 fi
 
 echo "\n# Running bundler-audit..."
-sh -c "bundle audit check --update"
+sh -c "bundle audit check --update ${INPUT_ARGS}"


### PR DESCRIPTION
Pass command-line arguments defined as the `:args` input of the step
into the `bundler-audit` command so CVEs can be ignored.

**Example:**

```yaml
jobs:
  static_analysis:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - uses: workarea-commerce/ci/bundler-audit@v1
      with:
        args: --ignore CVE-2015-9284
```

**Test Build:** https://github.com/workarea-commerce/workarea-facebook-login/commit/98e66fe3b92a4b4d545214b5b86c7d0b5618ce4d/checks

WORKAREA-141